### PR TITLE
Security hardening (HPF): sanitizeInput, dynamic field whitelist, inherited sharing

### DIFF
--- a/force-app/main/default/classes/AIAlertingService.cls
+++ b/force-app/main/default/classes/AIAlertingService.cls
@@ -3,7 +3,7 @@
  * @author RouteLogic Enhanced
  * @version 3.1.2
  */
-public with sharing class AIAlertingService {
+public inherited sharing class AIAlertingService {
     
     // Alert severity constants
     public static final String SEVERITY_CRITICAL = 'Critical';

--- a/force-app/main/default/classes/AIBulkOperationService.cls
+++ b/force-app/main/default/classes/AIBulkOperationService.cls
@@ -1,4 +1,22 @@
-public with sharing class AIBulkOperationService {
+public inherited sharing class AIBulkOperationService {
+
+    @testVisible private static Boolean isValidFieldName(String objectApiName, String fieldApiName) {
+        if (String.isBlank(objectApiName) || String.isBlank(fieldApiName)) return false;
+        if (fieldApiName.contains('.')) return false; // disallow relationship traversal
+        Schema.SObjectType sObjType = Schema.getGlobalDescribe().get(objectApiName);
+        if (sObjType == null) return false;
+        Map<String, Schema.SObjectField> fields = sObjType.getDescribe().fields.getMap();
+        return fields.containsKey(fieldApiName);
+    }
+
+    @testVisible private static Boolean areValidWhereParams(String objectApiName, Map<String, Object> whereParams) {
+        if (whereParams == null) return true;
+        for (String key : whereParams.keySet()) {
+            if (!isValidFieldName(objectApiName, key)) return false;
+        }
+        return true;
+    }
+
     private static final Integer DEFAULT_BATCH_SIZE = 200;
     private static final Integer MAX_BATCH_SIZE = 2000;
     
@@ -287,6 +305,14 @@ public with sharing class AIBulkOperationService {
         Map<String, Object> whereParams, // Changed from String whereClause to Map<String, Object>
         BulkConfig config
     ) {
+
+        // Validate dynamic inputs strictly
+        if (!isValidFieldName(objectType, fieldName)) {
+            throw new RouteLogicValidationException('Invalid or unsupported field name: ' + fieldName);
+        }
+        if (!areValidWhereParams(objectType, whereParams)) {
+            throw new RouteLogicValidationException('Invalid where parameters: only direct field API names are allowed');
+        }
         BulkOperationResult result = new BulkOperationResult();
         Long startTime = DateTime.now().getTime();
         

--- a/force-app/main/default/classes/AIBulkOperationService_WhitelistTest.cls
+++ b/force-app/main/default/classes/AIBulkOperationService_WhitelistTest.cls
@@ -1,0 +1,18 @@
+@IsTest
+private class AIBulkOperationService_WhitelistTest {
+    @IsTest static void validFieldName_Passes() {
+        System.assertEquals(true, AIBulkOperationService.isValidFieldName('Account', 'Name'));
+    }
+    @IsTest static void invalidFieldName_Fails() {
+        System.assertEquals(false, AIBulkOperationService.isValidFieldName('Account', 'DoesNotExist__c'));
+        System.assertEquals(false, AIBulkOperationService.isValidFieldName('Account', 'Owner.Name'));
+    }
+    @IsTest static void validWhereParams_Passes() {
+        Map<String,Object> wp = new Map<String,Object>{ 'Name' => 'Acme' };
+        System.assertEquals(true, AIBulkOperationService.areValidWhereParams('Account', wp));
+    }
+    @IsTest static void invalidWhereParams_Fails() {
+        Map<String,Object> wp = new Map<String,Object>{ 'Owner.Name' => 'Smith' };
+        System.assertEquals(false, AIBulkOperationService.areValidWhereParams('Account', wp));
+    }
+}

--- a/force-app/main/default/classes/AIBulkOperationService_WhitelistTest.cls-meta.xml
+++ b/force-app/main/default/classes/AIBulkOperationService_WhitelistTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>60.0</apiVersion>
+  <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/AgnosticRoutingEngine.cls
+++ b/force-app/main/default/classes/AgnosticRoutingEngine.cls
@@ -14,7 +14,7 @@
  * - Improved error handling with security context
  * - Multi-object support preparation
  */
-public with sharing class AgnosticRoutingEngine {
+public inherited sharing class AgnosticRoutingEngine {
     
     // Core routing constants
     private static final String HIGH_PRIORITY = 'High';

--- a/force-app/main/default/classes/RouteLogicInputValidator.cls
+++ b/force-app/main/default/classes/RouteLogicInputValidator.cls
@@ -151,14 +151,9 @@ public with sharing class RouteLogicInputValidator {
             return input;
         }
         
-        // Remove potentially dangerous characters
-        String sanitized = input;
-        
-        // Escape single quotes for SOQL
-        sanitized = sanitized.replace('\'', '\\\'');
-        
-        // Remove script tags and other HTML
-        sanitized = sanitized.replaceAll('<[^>]+>', '');
+        // Prefer bind variables for SOQL/SOSL. This helper only escapes single quotes
+        // to preserve content while preventing quote breaking in rare dynamic cases.
+        return String.escapeSingleQuotes(input);
         
         // Remove SQL injection patterns
         sanitized = sanitized.replaceAll('(?i)(union|select|insert|update|delete|drop)', '');

--- a/force-app/main/default/classes/RouteLogicInputValidatorTest.cls
+++ b/force-app/main/default/classes/RouteLogicInputValidatorTest.cls
@@ -1,0 +1,12 @@
+@IsTest
+private class RouteLogicInputValidatorTest {
+    @IsTest static void sanitizeInput_EscapesSingleQuotesOnly() {
+        String input = 'O'Hara <b>select drop</b>';
+        String out = RouteLogicInputValidator.sanitizeInput(input);
+        System.assertEquals('O''Hara <b>select drop</b>', out);
+    }
+    @IsTest static void sanitizeInput_BlankUnchanged() {
+        System.assertEquals(null, RouteLogicInputValidator.sanitizeInput(null));
+        System.assertEquals('', RouteLogicInputValidator.sanitizeInput(''));
+    }
+}

--- a/force-app/main/default/classes/RouteLogicInputValidatorTest.cls-meta.xml
+++ b/force-app/main/default/classes/RouteLogicInputValidatorTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>60.0</apiVersion>
+  <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
This is a Droid-assisted PR implementing the agreed high‑priority fixes.

Scope
- Input sanitization: RouteLogicInputValidator.sanitizeInput now uses String.escapeSingleQuotes only. Guidance: rely on bind variables for SOQL/SOSL; avoid blacklist HTML/keyword stripping.
- Dynamic field whitelist: AIBulkOperationService validates fieldName and whereParams against schema (no relationship traversal). Continues to use Database.queryWithBinds(…, AccessLevel.USER_MODE), WITH SECURITY_ENFORCED, and Security.stripInaccessible for FLS.
- Enforce inherited sharing on service classes: AIAlertingService, AIBulkOperationService, AgnosticRoutingEngine.
- Tests: add RouteLogicInputValidatorTest and AIBulkOperationService_WhitelistTest.

Validation
- Branch: feat/security-hardening-hpf
- Working tree clean
- Recommend running org tests post-deploy: `sf apex run test --test-level RunLocalTests` in a sandbox.

Rationale
- Replaces brittle blacklist sanitization with platform-safe escaping and bind-variable guidance.
- Prevents dynamic SOQL field injection by schema allowlist.
- Aligns service entry points to inherited sharing to respect caller context.

Droid-assisted PR.

---
**Factory Session:** https://app.factory.ai/sessions/vQegDg2QgjVQXJnNtTJI (created by MakeWorkTakesWork)