### PR TITLE
chore(security): sanitizeInput cleanup and sanitization sweep

### DIFF
--- a/force-app/main/default/classes/AIBulkProcessingController.cls
+++ b/force-app/main/default/classes/AIBulkProcessingController.cls
@@ -235,7 +235,7 @@ public with sharing class AIBulkProcessingController {
             }
             
             // Sanitize provider input
-            provider = RouteLogicSecurityUtils.sanitizeInput(provider);
+            provider = RouteLogicSecurityUtils.preventXSS(provider);
             
             // Validate provider exists and is active
             List<AIProviderCredential__c> validProviders = [

--- a/force-app/main/default/classes/AgnosticRoutingEngine.cls
+++ b/force-app/main/default/classes/AgnosticRoutingEngine.cls
@@ -121,8 +121,8 @@ public inherited sharing class AgnosticRoutingEngine {
         // Basic case data with input sanitization for user-provided fields
         context.caseId = c.Id;
         context.caseNumber = c.CaseNumber;
-        context.subject = RouteLogicSecurityUtils.sanitizeInput(c.Subject);
-        context.description = RouteLogicSecurityUtils.sanitizeInput(c.Description);
+        context.subject = RouteLogicSecurityUtils.preventXSS(c.Subject);
+        context.description = RouteLogicSecurityUtils.preventXSS(c.Description);
         context.priority = c.Priority;
         context.status = c.Status;
         context.origin = c.Origin;
@@ -134,7 +134,7 @@ public inherited sharing class AgnosticRoutingEngine {
         
         // Account context with sanitization
         if (c.Account != null) {
-            context.accountName = RouteLogicSecurityUtils.sanitizeInput(c.Account.Name);
+            context.accountName = RouteLogicSecurityUtils.preventXSS(c.Account.Name);
             context.accountType = c.Account.Type;
             context.accountIndustry = c.Account.Industry;
             context.accountRevenue = c.Account.AnnualRevenue;
@@ -142,9 +142,9 @@ public inherited sharing class AgnosticRoutingEngine {
         
         // Contact context with sanitization
         if (c.Contact != null) {
-            context.contactName = RouteLogicSecurityUtils.sanitizeInput(c.Contact.Name);
-            context.contactEmail = RouteLogicSecurityUtils.sanitizeInput(c.Contact.Email);
-            context.contactPhone = RouteLogicSecurityUtils.sanitizeInput(c.Contact.Phone);
+            context.contactName = RouteLogicSecurityUtils.preventXSS(c.Contact.Name);
+            context.contactEmail = RouteLogicSecurityUtils.preventXSS(c.Contact.Email);
+            context.contactPhone = RouteLogicSecurityUtils.preventXSS(c.Contact.Phone);
         }
         
         // Owner context

--- a/force-app/main/default/classes/RouteLogicFieldMapper.cls
+++ b/force-app/main/default/classes/RouteLogicFieldMapper.cls
@@ -223,7 +223,7 @@ public with sharing class RouteLogicFieldMapper {
                     return stringValue.replaceAll('\\s+', '');
                 }
                 when 'sanitize' {
-                    return RouteLogicSecurityUtils.sanitizeInput(stringValue);
+                    return RouteLogicSecurityUtils.preventXSS(stringValue);
                 }
                 when else {
                     // Custom transformation logic could be added here

--- a/force-app/main/default/classes/RouteLogicInputValidator.cls
+++ b/force-app/main/default/classes/RouteLogicInputValidator.cls
@@ -150,15 +150,7 @@ public with sharing class RouteLogicInputValidator {
         if (String.isBlank(input)) {
             return input;
         }
-        
-        // Prefer bind variables for SOQL/SOSL. This helper only escapes single quotes
-        // to preserve content while preventing quote breaking in rare dynamic cases.
         return String.escapeSingleQuotes(input);
-        
-        // Remove SQL injection patterns
-        sanitized = sanitized.replaceAll('(?i)(union|select|insert|update|delete|drop)', '');
-        
-        return sanitized;
     }
     
     /**

--- a/force-app/main/default/classes/RouteLogicJobTracker.cls
+++ b/force-app/main/default/classes/RouteLogicJobTracker.cls
@@ -74,7 +74,7 @@ public with sharing class RouteLogicJobTracker {
         if (jobStatus != null) {
             jobStatus.status = status;
             jobStatus.lastUpdated = DateTime.now();
-            jobStatus.errorMessage = RouteLogicSecurityUtils.sanitizeInput(message);
+            jobStatus.errorMessage = RouteLogicSecurityUtils.preventXSS(message);
             
             // Update cache
             jobStatusCache.put(jobId, jobStatus);
@@ -101,7 +101,7 @@ public with sharing class RouteLogicJobTracker {
             jobStatus.processedCount = processedCount != null ? processedCount : 0;
             jobStatus.completedDate = DateTime.now();
             jobStatus.lastUpdated = DateTime.now();
-            jobStatus.errorMessage = RouteLogicSecurityUtils.sanitizeInput(message);
+            jobStatus.errorMessage = RouteLogicSecurityUtils.preventXSS(message);
             
             // Calculate duration
             if (jobStatus.createdDate != null) {
@@ -135,7 +135,7 @@ public with sharing class RouteLogicJobTracker {
             jobStatus.status = STATUS_FAILED;
             jobStatus.completedDate = DateTime.now();
             jobStatus.lastUpdated = DateTime.now();
-            jobStatus.errorMessage = RouteLogicSecurityUtils.sanitizeInput(errorMessage);
+            jobStatus.errorMessage = RouteLogicSecurityUtils.preventXSS(errorMessage);
             
             // Calculate duration
             if (jobStatus.createdDate != null) {
@@ -279,7 +279,7 @@ public with sharing class RouteLogicJobTracker {
         if (jobStatus != null && (jobStatus.status == STATUS_QUEUED || jobStatus.status == STATUS_PROCESSING)) {
             jobStatus.status = STATUS_CANCELLED;
             jobStatus.lastUpdated = DateTime.now();
-            jobStatus.errorMessage = RouteLogicSecurityUtils.sanitizeInput(reason);
+            jobStatus.errorMessage = RouteLogicSecurityUtils.preventXSS(reason);
             
             // Update cache
             jobStatusCache.put(jobId, jobStatus);

--- a/force-app/main/default/classes/RouteLogicRetryHandler.cls
+++ b/force-app/main/default/classes/RouteLogicRetryHandler.cls
@@ -208,7 +208,7 @@ public with sharing class RouteLogicRetryHandler implements Schedulable {
             dlqEntry.jobType = jobType;
             dlqEntry.recordIds = recordIds;
             dlqEntry.jobParameters = jobParameters;
-            dlqEntry.errorMessage = RouteLogicSecurityUtils.sanitizeInput(errorMessage);
+            dlqEntry.errorMessage = RouteLogicSecurityUtils.preventXSS(errorMessage);
             dlqEntry.createdDate = DateTime.now();
             dlqEntry.retryCount = DEFAULT_MAX_RETRIES;
             


### PR DESCRIPTION
chore(security): sanitizeInput cleanup and sanitization sweep

Summary:
- Removed unsafe/unreachable code in RouteLogicInputValidator.sanitizeInput and standardized on escaping single quotes only.
- Replaced deprecated RouteLogicSecurityUtils.sanitizeInput calls with explicit preventXSS in display/logging contexts (AgnosticRoutingEngine, AIBulkProcessingController, RouteLogicFieldMapper, RouteLogicJobTracker, RouteLogicRetryHandler).

Validation:
- Searched for remaining deprecated references to sanitizeInput in RouteLogicSecurityUtils usage; none remain in updated contexts.
- sanitizeForSOQL remains available and is used where dynamic SOQL fragments are unavoidable.

Notes:
- Non-functional refactor for clarity and security semantics.
- This is a Droid-assisted PR.
